### PR TITLE
Modify code that picks a GPU

### DIFF
--- a/VulkanizedEngine.hpp
+++ b/VulkanizedEngine.hpp
@@ -650,8 +650,8 @@ private:
         }
 
         // Check if the best candidate is suitable
-        if(candidates.begin()->first > 0){
-            physicalDevice = candidates.begin()->second;
+        if(candidates.rbegin()->first > 0){
+            physicalDevice = candidates.rbegin()->second;
         }
         else{
             throw std::runtime_error("Failed to find a suitable GPU!");


### PR DESCRIPTION
Changed the function pickPhysicalDevice() to start at the end of the map rather than at the beginning. The map sorts from lowest to highest score rather than highest to lowest, meaning that the function used to pick the GPU with the lowest score by default.